### PR TITLE
Fixing build without RTL

### DIFF
--- a/acarsdec.c
+++ b/acarsdec.c
@@ -154,9 +154,11 @@ int main(int argc, char **argv)
 			inmode = 4;
 			break;
 #endif
+#ifdef WITH_RTL
 		case 'g':
 			gain = atoi(optarg);
 			break;
+#endif
 		case 'n':
 			Rawaddr = optarg;
 			netout = 0;


### PR DESCRIPTION
Not referencing "gain" when WITH_RTL isn't defined.