### PR TITLE
No longer attempt to decode flight ID or message number for uplink messages

### DIFF
--- a/output.c
+++ b/output.c
@@ -350,7 +350,7 @@ void outputmsg(const msgblk_t * blk)
 		return;
 
 	if (msg.bs != 0x03) {
-		if (msg.mode <= 'Z') {
+		if (msg.mode <= 'Z' && msg->bid <= '9') {
 			/* message no */
 			for (i = 0; i < 4 && k < blk->len - 1; i++, k++) {
 				msg.no[i] = blk->txt[k];

--- a/output.c
+++ b/output.c
@@ -350,7 +350,7 @@ void outputmsg(const msgblk_t * blk)
 		return;
 
 	if (msg.bs != 0x03) {
-		if (msg.mode <= 'Z' && msg->bid <= '9') {
+		if (msg.mode <= 'Z' && msg.bid <= '9') {
 			/* message no */
 			for (i = 0; i < 4 && k < blk->len - 1; i++, k++) {
 				msg.no[i] = blk->txt[k];


### PR DESCRIPTION
Uplink messages (block IDs A-Z) have no flight ID or message number for any of the message sources I have access to.
