### PR TITLE
Make uplink messages have an associated FlightID in acarsserv

### DIFF
--- a/acarsserv.c
+++ b/acarsserv.c
@@ -97,11 +97,10 @@ static void processpkt(acarsmsg_t * msg, char *ipaddr)
 	int lm;
 
 	pr = strtok(msg->reg, " ");
-	pf = strtok(msg->fid, " ");
 	strtok(msg->no, " ");
 
 	lm = 0;
-	if (msg->mode < 0x5d && pr && pf)
+	if (msg->mode < 0x5d && pr)
 		lm = 1;
 
 	if ((lm || station) &&

--- a/dbmgn.c
+++ b/dbmgn.c
@@ -39,7 +39,7 @@ int initdb(char *dbname)
 	sql[TET] = "end transaction";
 	sql[TRL] = "rollback transaction";
 	sql[TSELFLG] =
-	    "select FlightID from Flights where Registration = ?1 and FlightNumber = ?2 and datetime(LastTime,'30 minutes') > datetime(?3,'unixepoch');";
+	    "select FlightID from Flights where Registration = ?1 and datetime(LastTime,'30 minutes') > datetime(?3,'unixepoch') and (FlightNumber = ?2 or ?2 = '      ') order by LastTime desc limit 1;";
 	sql[TINSFLG] =
 	    "insert into Flights (Registration,FlightNumber,StartTime,LastTime) values (?1,?2,datetime(?3,'unixepoch'),datetime(?3,'unixepoch')) ;";
 	sql[TUPFLG] =


### PR DESCRIPTION
Currently the `FlightID` is always 0 for uplink messages. This fix associates them with the most recently updated `FlightID` for their `Registration` (if it has not been more than 30 minutes since the last update). If there is no `FlightID` with the uplink messages's`Registration`, then a new `FlightID` is created with a blank `FlightNumber`, because there is no known `FlightNumber` for that message.