### PR TITLE
flush output fd rather than waiting for the stream buffer to fill

### DIFF
--- a/output.c
+++ b/output.c
@@ -519,6 +519,7 @@ void outputmsg(const msgblk_t * blk)
 		break;
 	case OUTTYPE_JSON:
 		fprintf(fdout, "%s\n", jsonbuf);
+		fflush(fdout);
 		break;
 	}
 }


### PR DESCRIPTION
This way the json logfile will always have a complete line, rather than possibly being interruped in the middle of a line.