### PR TITLE
Fix compile error

### DIFF
--- a/output.c
+++ b/output.c
@@ -436,8 +436,8 @@ void outputmsg(const msgblk_t * blk)
 	k++;
 
         for (i = 0, j = 0; i < 7; i++, k++) {
-                if (txt[k] != '.') {
-                        msg.addr[j] = txt[k];
+                if (blk->txt[k] != '.') {
+                        msg.addr[j] = blk->txt[k];
                         j++;
                 }
         }


### PR DESCRIPTION
output.c: In function ‘outputmsg’:
output.c:439:21: error: ‘txt’ undeclared (first use in this function)
                 if (txt[k] != '.') {
                     ^
output.c:439:21: note: each undeclared identifier is reported only once for each function it appears in