### PR TITLE
Small tweak due to an API change in libacars v. 1.1.0

### DIFF
--- a/acarsdec.c
+++ b/acarsdec.c
@@ -59,15 +59,12 @@ char *logfilename = NULL;
 static void usage(void)
 {
 	fprintf(stderr,
-		"Acarsdec/acarsserv 3.5 %sCopyright (c) 2017 Thierry Leconte \n\n",
+		"Acarsdec/acarsserv 3.5 Copyright (c) 2017 Thierry Leconte\n");
 #ifdef HAVE_LIBACARS
-		"(libacars " LA_VERSION ") "
-#else
-		""
+	fprintf(stderr,	"(libacars %s)\n", LA_VERSION);
 #endif
-		);
 	fprintf(stderr,
-		"Usage: acarsdec  [-v] [-o lv] [-t time] [-A] [-n ipaddr:port] [-l logfile]");
+		"\nUsage: acarsdec  [-v] [-o lv] [-t time] [-A] [-n ipaddr:port] [-l logfile]");
 #ifdef WITH_ALSA
 	fprintf(stderr, " -a alsapcmdevice  |");
 #endif


### PR DESCRIPTION
I have changed LA_VERSION from a preprocessor macro into a variable, so that it shows the library version which is currently running instead of the version which the program has been compiled with. This causes acarsdec compilation to fail, hence this fix. Sorry for trouble, in the future I'll do my best to keep the API backwards compatible as long as I can.