### PR TITLE
Fix for message direction determination

### DIFF
--- a/output.c
+++ b/output.c
@@ -225,7 +225,7 @@ static void printmsg(acarsmsg_t * msg, int chn, struct timeval tv)
 		fprintf(fdout, "Id : %1c ", msg->bid);
 		if(msg->ack==0x15) fprintf(fdout, "Nak\n"); else fprintf(fdout, "Ack : %1c\n", msg->ack);
 		fprintf(fdout, "Aircraft reg: %s ", msg->addr);
-		if(msg->mode <= 'Z') {
+		if(msg->bid >= '0' && msg->bid <= '9') {
 			fprintf(fdout, "Flight id: %s\n", msg->fid);
 			fprintf(fdout, "No: %4s", msg->no);
 		}
@@ -294,7 +294,7 @@ static int buildjson(acarsmsg_t * msg, int chn, struct timeval tv)
 		}
 
 		cJSON_AddStringToObject(json_obj, "tail", msg->addr);
-		if(msg->mode <= 'Z') {
+		if(msg->bid >= '0' && msg->bid <= '9') {
 			cJSON_AddStringToObject(json_obj, "flight", msg->fid);
 			cJSON_AddStringToObject(json_obj, "msgno", msg->no);
 		}
@@ -530,11 +530,11 @@ void outputmsg(const msgblk_t * blk)
 	msg.fid[0] = '\0';
 	msg.txt[0] = '\0';
 
-	if ((msg.bs == 0x03 || msg.mode > 'Z') && airflt)
+	if (airflt && !(msg.bid >= '0' && msg.bid <= '9'))
 		return;
 
 	if (msg.bs != 0x03) {
-		if (msg.mode <= 'Z' && msg.bid <= '9') {
+		if (msg.bid >= '0' && msg.bid <= '9') {
 			/* message no */
 			for (i = 0; i < 4 && k < blk->len - 1; i++, k++) {
 				msg.no[i] = blk->txt[k];


### PR DESCRIPTION
Using Mode character is not the correct way to discriminate between uplink and downlink messages because in VHF ACARS Category A network operation mode "2" is used in both directions. This causes the following problems:

- Uplink messages with mode "2" are always logged, regardless of whether `-A` option is used or not:

```
[#2 (F:131.825 L:-26 E:0) 27/02/2019 21:32:50.268 --------------------------------
Mode : 2 Label : SQ
A15210N02058EB136975/ARINC
```

This is an uplink squitter message which should not be logged when `-A` option is enabled.

- Uplinks with mode "2" are logged with empty Flight Id and Msg no. fields:
```
[#2 (F:131.825 L:-26 E:0) 27/02/2019 21:24:14.907 --------------------------------
Mode : 2 Label : H1 Id : Y Nak
Aircraft reg: N713CK Flight id:
No:
- #MDREQPOS037B
```

These fields shall only be printed for downlink messages. They are not present in uplinks.

This patch causes message direction to be determined based solely on Block Id character. If it's a digit, then the message is a downlink, otherwise it's an uplink. This works reliably both in ACARS category A and B.