### PR TITLE
Support for automatic output file rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ as the RTLSDR dongle, the AIRspy and the SDRplay device.
 It allows the user to directly monitor to up to 8 different frequencies simultaneously with very low cost hardware.
 
 ## Usage
-> acarsdec  [-v] [-o lv] [-t time] [-A] [-n|N|j ipaddr:port] [-i stationid] [-l logfile] -r rtldevicenumber  f1 [f2] [... fN] | -s f1 [f2] [... fN]
+> acarsdec  [-v] [-o lv] [-t time] [-A] [-n|N|j ipaddr:port] [-i stationid] [-l logfile [-H|-D]] -r rtldevicenumber  f1 [f2] [... fN] | -s f1 [f2] [... fN]
 
  -v :			verbose
  
@@ -26,7 +26,11 @@ It allows the user to directly monitor to up to 8 different frequencies simultan
  
  -t time :		set forget time (TTL) in seconds in monitor mode(default=600s)
  
- -l logfile :		Append log messages to logfile (Default : stdout)
+ -l logfile :		append log messages to logfile (Default : stdout)
+
+ -H :			rotate log file once every hour
+
+ -D :			rotate log file once every day
  
  -n ipaddr:port :	send acars messages to addr:port via UDP in planeplotter compatible format
  

--- a/acarsdec.c
+++ b/acarsdec.c
@@ -40,6 +40,8 @@ int outtype = OUTTYPE_STD;
 int netout = NETLOG_NONE;
 int airflt = 0;
 int mdly=600;
+int hourly = 0;
+int daily = 0;
 
 #ifdef WITH_RTL
 int gain = 1000;
@@ -154,7 +156,7 @@ int main(int argc, char **argv)
 	idstation = strndup(sys_hostname, 8);
 
 	res = 0;
-	while ((c = getopt(argc, argv, "varfsRo:t:g:Ap:n:N:j:l:c:i:L:G:b:")) != EOF) {
+	while ((c = getopt(argc, argv, "HDvarfsRo:t:g:Ap:n:N:j:l:c:i:L:G:b:")) != EOF) {
 
 		switch (c) {
 		case 'v':
@@ -235,6 +237,12 @@ int main(int argc, char **argv)
 		case 'l':
 			logfilename = optarg;
 			break;
+		case 'H':
+			hourly = 1;
+			break;
+		case 'D':
+			daily = 1;
+			break;
 		case 'i':
 			idstation = strndup(optarg, 8);
 			break;
@@ -252,6 +260,11 @@ int main(int argc, char **argv)
 	if (res) {
 		fprintf(stderr, "Unable to init input\n");
 		exit(res);
+	}
+
+	if(hourly && daily) {
+		fprintf(stderr, "Options: -H and -D are exclusive\n");
+		exit(1);
 	}
 
 	build_label_filter(lblf);

--- a/acarsdec.c
+++ b/acarsdec.c
@@ -66,7 +66,7 @@ static void usage(void)
 	fprintf(stderr,	"(libacars %s)\n", LA_VERSION);
 #endif
 	fprintf(stderr,
-		"\nUsage: acarsdec  [-v] [-o lv] [-t time] [-A] [-n ipaddr:port] [-l logfile]");
+		"\nUsage: acarsdec  [-v] [-o lv] [-t time] [-A] [-n ipaddr:port] [-l logfile [-H|-D]]");
 #ifdef WITH_ALSA
 	fprintf(stderr, " -a alsapcmdevice  |");
 #endif
@@ -93,7 +93,11 @@ static void usage(void)
 	fprintf(stderr,
 		"\n -t time\t\t: set forget time (TTL) in seconds for monitor mode (default=600s)\n");
 	fprintf(stderr,
-		" -l logfile\t\t: Append log messages to logfile (Default : stdout).\n");
+		" -l logfile\t\t: append log messages to logfile (Default : stdout).\n");
+	fprintf(stderr,
+		" -H\t\t\t: rotate log file once every hour\n");
+	fprintf(stderr,
+		" -D\t\t\t: rotate log file once every day\n");
 	fprintf(stderr,
 		" -n ipaddr:port\t\t: send acars messages to addr:port on UDP in planeplotter compatible format\n");
 	fprintf(stderr,

--- a/acarsdec.h
+++ b/acarsdec.h
@@ -125,6 +125,7 @@ extern int outtype;
 extern int netout;
 extern int airflt;
 extern int mdly;
+extern int hourly, daily;
 
 extern int gain;
 extern int ppm;

--- a/output.c
+++ b/output.c
@@ -7,6 +7,7 @@
 #include <sys/socket.h>
 #include <time.h>
 #include <netdb.h>
+#include <errno.h>
 #ifdef HAVE_LIBACARS
 #include <libacars/libacars.h>
 #include <libacars/acars.h>
@@ -21,6 +22,10 @@ extern char *idstation;
 
 static int sockfd = -1;
 static FILE *fdout;
+static char *filename_prefix = NULL;
+static char *extension = NULL;
+static size_t prefix_len;
+static struct tm current_tm;
 
 static char *jsonbuf=NULL;
 #define JSONBUFLEN 30000
@@ -28,6 +33,44 @@ static char *jsonbuf=NULL;
 static inline void cls(void)
 {
 	printf("\x1b[H\x1b[2J");
+}
+
+static int open_outfile() {
+	char *filename = NULL;
+	char *fmt = NULL;
+	size_t tlen = 0;
+
+	if(hourly || daily) {
+		time_t t = time(NULL);
+		gmtime_r(&t, &current_tm);
+		char suffix[16];
+		if(hourly) {
+			fmt = "_%Y%m%d_%H";
+		} else {	// daily
+			fmt = "_%Y%m%d";
+		}
+		tlen = strftime(suffix, sizeof(suffix), fmt, &current_tm);
+		if(tlen == 0) {
+			fprintf(stderr, "open_outfile(): strfime returned 0\n");
+			return -1;
+		}
+		filename = calloc(prefix_len + tlen + 2, sizeof(char));
+		if(filename == NULL) {
+			fprintf(stderr, "open_outfile(): failed to allocate memory\n");
+			return -1;
+		}
+		sprintf(filename, "%s%s%s", filename_prefix, suffix, extension);
+	} else {
+		filename = strdup(filename_prefix);
+	}
+
+	if((fdout = fopen(filename, "a+")) == NULL) {
+		fprintf(stderr, "Could not open output file %s: %s\n", filename, strerror(errno));
+		free(filename);
+		return -1;
+	}
+	free(filename);
+	return 0;
 }
 
 int initOutput(char *logfilename, char *Rawaddr)
@@ -38,13 +81,31 @@ int initOutput(char *logfilename, char *Rawaddr)
 	int rv;
 
 	if (logfilename) {
-		fdout = fopen(logfilename, "a+");
-		if (fdout == NULL) {
-			fprintf(stderr, "Could not open : %s\n", logfilename);
-			return -1;
+		filename_prefix = logfilename;
+		prefix_len = strlen(filename_prefix);
+		if(hourly || daily) {
+			char *basename = strrchr(filename_prefix, '/');
+			if(basename != NULL) {
+				basename++;
+			} else {
+				basename = filename_prefix;
+			}
+			char *ext = strrchr(filename_prefix, '.');
+			if(ext != NULL && (ext <= basename || ext[1] == '\0')) {
+				ext = NULL;
+			}
+			if(ext) {
+				extension = strdup(ext);
+				*ext = '\0';
+			} else {
+				extension = strdup("");
+			}
 		}
-	} else
+		return open_outfile();
+	} else {
 		fdout = stdout;
+		hourly = daily = 0;	// stdout is not rotateable
+	}
 
 	if (Rawaddr) {
 
@@ -111,6 +172,18 @@ int initOutput(char *logfilename, char *Rawaddr)
 		jsonbuf = malloc(JSONBUFLEN+1);
 	}
 	
+	return 0;
+}
+
+static int rotate_outfile() {
+	struct tm new_tm;
+	time_t t = time(NULL);
+	gmtime_r(&t, &new_tm);
+	if((hourly && new_tm.tm_hour != current_tm.tm_hour) ||
+	   (daily && new_tm.tm_mday != current_tm.tm_mday)) {
+		fclose(fdout);
+		return open_outfile();
+	}
 	return 0;
 }
 
@@ -572,6 +645,9 @@ void outputmsg(const msgblk_t * blk)
 			jok=buildjson(&msg, blk->chn, blk->tv);
 	}
 
+	if((hourly || daily) && rotate_outfile() < 0) {
+		_exit(1);
+	}
 	switch (outtype) {
 	case OUTTYPE_NONE:
 		break;

--- a/output.c
+++ b/output.c
@@ -80,7 +80,7 @@ int initOutput(char *logfilename, char *Rawaddr)
 	struct addrinfo hints, *servinfo, *p;
 	int rv;
 
-	if (logfilename) {
+	if (outtype != OUTTYPE_NONE && logfilename) {
 		filename_prefix = logfilename;
 		prefix_len = strlen(filename_prefix);
 		if(hourly || daily) {
@@ -645,7 +645,7 @@ void outputmsg(const msgblk_t * blk)
 			jok=buildjson(&msg, blk->chn, blk->tv);
 	}
 
-	if((hourly || daily) && rotate_outfile() < 0) {
+	if((hourly || daily) && outtype != OUTTYPE_NONE && rotate_outfile() < 0) {
 		_exit(1);
 	}
 	switch (outtype) {


### PR DESCRIPTION
This patch adds two command line options:

- `-H` - rotates the output file on top of every hour
- `-D` - rotates the output file at midnight

Output file name provided with the `-l` option gets suffixed automatically with `_YYYYMMDD_HH` or `_YYYYMMDD` string, respectively. If the given base file name has an extension suffix starting with a dot, then the extension is moved to the end of the resulting filename. That is, supplying `-l /home/pi/acars.log -D` options produces a filename of `/home/pi/acars_YYYYMMDD.log` instead of `/home/pi/acars.log_YYYYMMDD`. If neither `-H` nor `-D` option is used, the program behaves the old way.

An additional change is when the `-o 0` option is given together with `-l <output_file>`, then the output file is not opened nor created at all.

This feature simplifies log file management and archiving by avoiding periodic program restarts, when rotation is required.