### PR TITLE
initOutput(): don't return unless open_outfile() returns an error

### DIFF
--- a/output.c
+++ b/output.c
@@ -101,7 +101,8 @@ int initOutput(char *logfilename, char *Rawaddr)
 				extension = strdup("");
 			}
 		}
-		return open_outfile();
+		if(open_outfile() < 0)
+			return -1;
 	} else {
 		fdout = stdout;
 		hourly = daily = 0;	// stdout is not rotateable


### PR DESCRIPTION
Otherwise network output will be left unititialized. Fixes https://github.com/TLeconte/acarsdec/issues/55

Sorry about that.