### PR TITLE
Expand ID string to 32 chars (acarsdec)

### DIFF
--- a/acarsdec.c
+++ b/acarsdec.c
@@ -157,7 +157,7 @@ int main(int argc, char **argv)
 	char *lblf=NULL;
 
 	gethostname(sys_hostname, sizeof(sys_hostname));
-	idstation = strndup(sys_hostname, 8);
+	idstation = strndup(sys_hostname, 32);
 
 	res = 0;
 	while ((c = getopt(argc, argv, "HDvarfsRo:t:g:Ap:n:N:j:l:c:i:L:G:b:")) != EOF) {
@@ -248,7 +248,8 @@ int main(int argc, char **argv)
 			daily = 1;
 			break;
 		case 'i':
-			idstation = strndup(optarg, 8);
+			free(idstation);
+			idstation = strndup(optarg, 32);
 			break;
 
 		default:

--- a/acarsdec.c
+++ b/acarsdec.c
@@ -24,6 +24,7 @@
 #include <getopt.h>
 #include <sched.h>
 #include <unistd.h>
+#include <limits.h>
 #ifdef HAVE_LIBACARS
 #include <libacars/version.h>
 #endif

--- a/acarsdec.c
+++ b/acarsdec.c
@@ -153,7 +153,7 @@ int main(int argc, char **argv)
 	int c;
 	int res, n;
 	struct sigaction sigact;
-	char sys_hostname[8];
+	char sys_hostname[HOST_NAME_MAX+1];
 	char *lblf=NULL;
 
 	gethostname(sys_hostname, sizeof(sys_hostname));


### PR DESCRIPTION
Hi,
(Same message for both acarsdec(THIS) and vdlm2dec)

In both vdl2mdec and acarsdec, there is a "station ID".  acarsdec has it limited to 8 characters, and vdlm2dec doesn't have a limit.  I'm proposing bringing these in line together, at 32 characters.  (Also, this fixes a bug in acarsdec that is missing a free() before re-assigning idstation via cmdline arg.)

NOTE: acarsserv would also need to be modified to allow up to 32 chars for the station ID.

-Taner