### PR TITLE
JSON output for messages decoded by libacars

### DIFF
--- a/acarsdec.h
+++ b/acarsdec.h
@@ -20,6 +20,9 @@
 #include <time.h>
 #include <pthread.h>
 #include <complex.h>
+#ifdef HAVE_LIBACARS
+#include <libacars/libacars.h>
+#endif
 
 #define MAXNBCHANNELS 8
 #define INTRATE 12500
@@ -109,6 +112,9 @@ typedef struct {
         char bs, be;
         char txt[250];
         int err, lvl;
+#ifdef HAVE_LIBACARS
+	la_proto_node *decoded_tree;
+#endif
 } acarsmsg_t;
 
 extern channel_t channel[MAXNBCHANNELS];

--- a/output.c
+++ b/output.c
@@ -249,7 +249,7 @@ void outsv(acarsmsg_t * msg, int chn, struct timeval tv)
 
 void outjson()
 {
-	char pkt[500];
+	char pkt[1400];
 
 	snprintf(pkt, sizeof(pkt), "%s\n", jsonbuf);
 	write(sockfd, pkt, strlen(pkt));


### PR DESCRIPTION
Hi Thierry,

I have added JSON output to libacars. All decoded fields are now available as JSON keys.This patch extends acarsdec JSON output with this data. Whenever libacars has decoded a message, a new "libacars" key is added to the JSON message produced by acarsdec and everything is stored there.

For example, the following media advisory message:

```
[#1 (F:131.725 L:-27 E:0) 25/01/2020 17:47:23.936 --------------------------------
Mode : G Label : SA Id : 9 Nak
Aircraft reg: A7-BAI Flight id: QR0001
No: S26A
0LS174722V
Media Advisory, version 0:
 Link Default SATCOM lost at 17:47:22 UTC
 Available links: VHF ACARS
```

produces the following JSON output:

```json
{
   "ack" : false,
   "block_id" : "9",
   "channel" : 0,
   "error" : 0,
   "flight" : "QR0001",
   "freq" : 131.725,
   "label" : "SA",
   "level" : -27,
   "libacars" : {
      "media-adv" : {
         "current_link" : {
            "code" : "S",
            "descr" : "Default SATCOM",
            "established" : false,
            "time" : {
               "hour" : 17,
               "min" : 47,
               "sec" : 22
            }
         },
         "err" : false,
         "links_avail" : [
            {
               "code" : "V",
               "descr" : "VHF ACARS"
            }
         ],
         "version" : "0"
      }
   },
   "mode" : "G",
   "msgno" : "S26A",
   "station_id" : "rasp04",
   "tail" : "A7-BAI",
   "text" : "0LS174722V",
   "timestamp" : 1579974443.93625
}
```

Example ADS-C message:

```
[#2 (F:131.825 L:-26 E:0) 09/08/2019 14:17:14.327 --------------------------------
Mode : 2 Label : B6 Id : 1 Nak
Aircraft reg: A6-EFF Flight id: EK9771
No: F23A
/DXBEGEK.ADS.A6-EFF072300207602C9C410231F6312
ADS-C message:
 Basic report:
  Lat: 49.2194366
  Lon: 20.7440758
  Alt: 40000 ft
  Time: 1032.750 sec past hour (:17:12.750)
  Position accuracy: <0.05 nm
  NAV unit redundancy: OK
  TCAS: OK
```

gives this:

```json
{
   "level" : -26,
   "ack" : false,
   "msgno" : "F23A",
   "tail" : "A6-EFF",
   "timestamp" : 1565360234.3276,
   "channel" : 1,
   "error" : 0,
   "freq" : 131.825,
   "block_id" : "1",
   "mode" : "2",
   "flight" : "EK9771",
   "text" : "/DXBEGEK.ADS.A6-EFF072300207602C9C410231F6312",
   "station_id" : "rasp04",
   "label" : "B6",
   "libacars" : {
      "arinc622" : {
         "air_addr" : ".A6-EFF",
         "adsc" : {
            "tags" : [
               {
                  "basic_report" : {
                     "alt" : 40000,
                     "nav_redundancy" : true,
                     "tcas_avail" : true,
                     "lon" : 20.744076,
                     "pos_accuracy_nm" : 0.05,
                     "ts_sec" : 1032.75,
                     "lat" : 49.219437
                  }
               }
            ],
            "err" : false
         },
         "msg_type" : "adsc_msg",
         "gs_addr" : "DXBEGEK",
         "crc_ok" : true
      }
   }
}
```

I had to enlarge the JSON buffer from 500 to 1400 bytes, because many messages simply didn't fit and the resulting JSON string got truncated. But it's still not 100% bulletproof solution - for example this beast encoded as JSON won't fit in 1400 bytes:

```
/DELCAYA.ADS.G-YMMG0722C4886DA0C9474E3F9D160186696928E02EE016010A69C128E04EE016042F643128E0D16016014A657128E0FA601600636A0133C906A0160033613138810CE016004361213881152016036F66793881850017241BE8346509C40CA50D230
ADS-C message:
 -- CRC check failed
 Basic report:
  Lat: 48.8920784
  Lon: 19.2705345
  Alt: 38004 ft
  Time: 911.875 sec past hour (:15:11.875)
  Position accuracy: <0.25 nm
  NAV unit redundancy: OK
  TCAS: OK
 Intermediate projection:
  Distance: 48.750 nm
  True track: 296.5 deg
  Alt: 38000 ft
  ETA: 375 sec
 Intermediate projection:
  Distance: 33.250 nm
  True track: 297.4 deg
  Alt: 38000 ft
  ETA: 631 sec
 Intermediate projection:
  Distance: 133.875 nm
  True track: 281.8 deg
  Alt: 38000 ft
  ETA: 1675 sec
 Intermediate projection:
  Distance: 41.250 nm
  True track: 285.3 deg
  Alt: 38000 ft
  ETA: 2003 sec
 Intermediate projection:
  Distance: 12.375 nm
  True track: 298.1 deg
  Alt: 39396 ft
  ETA: 2101 sec
 Intermediate projection:
  Distance: 6.375 nm
  True track: 273.3 deg
  Alt: 40000 ft
  ETA: 2151 sec
 Intermediate projection:
  Distance: 8.375 nm
  True track: 273.2 deg
  Alt: 40000 ft
  ETA: 2217 sec
 Intermediate projection:
  Distance: 109.875 nm
  True track: 288.2 deg
  Alt: 40000 ft
  ETA: 3112 sec
 Fixed projection:
  Lat: 50.7782936
  Lon: 9.2099762
  Alt: 40000 ft
  ETA: 3237 sec
```

A better option would be to drop the `pkt` buffer altogether and write the contents of `jsonbuf` to the socket directly. `jsonbuf` is 30000 bytes long, so this should be more than enough. What do you think?