### PR TITLE
Added reassembly status to json output

### DIFF
--- a/output.c
+++ b/output.c
@@ -460,6 +460,7 @@ static int buildjson(acarsmsg_t * msg, int chn, struct timeval tv)
 			cJSON_AddStringToObject(json_obj, "wlin", oooi.won);
 	}
 #ifdef HAVE_LIBACARS
+	cJSON_AddStringToObject(json_obj, "assstat", la_reasm_status_name_get(msg->reasm_status));
 	if(msg->decoded_tree != NULL) {
 		la_vstring *vstr = la_proto_tree_format_json(NULL, msg->decoded_tree);
 		cJSON_AddRawToObject(json_obj, "libacars", vstr->str);


### PR DESCRIPTION
I added the reassembly status to the json output, so that I can better parse the json output in [my project](https://github.com/Crisvirus/acarsinterface). 