### PR TITLE
Add skip reassembly option, add new keys to JSON output

### DIFF
--- a/acarsdec.h
+++ b/acarsdec.h
@@ -152,6 +152,9 @@ extern	int	lnaState;
 extern	int	GRdB;
 extern int initOutput(char*,char *);
 
+#ifdef HAVE_LIBACARS
+extern int skip_reassembly;
+#endif
 #ifdef WITH_ALSA
 extern int initAlsa(char **argv,int optind);
 extern int runAlsaSample(void);

--- a/output.c
+++ b/output.c
@@ -124,7 +124,7 @@ int initOutput(char *logfilename, char *Rawaddr)
 		jsonbuf = malloc(JSONBUFLEN+1);
 	}
 #ifdef HAVE_LIBACARS
-	reasm_ctx = la_reasm_ctx_new();
+	reasm_ctx = skip_reassembly ? NULL : la_reasm_ctx_new();
 #endif
 	return 0;
 }
@@ -187,7 +187,9 @@ static void printmsg(acarsmsg_t * msg, int chn, struct timeval tv)
 			}
 		}
 #ifdef HAVE_LIBACARS
-		fprintf(fdout, "\nReassembly: %s", la_reasm_status_name_get(msg->reasm_status));
+		if (!skip_reassembly) {
+			fprintf(fdout, "\nReassembly: %s", la_reasm_status_name_get(msg->reasm_status));
+		}
 #endif
 	}
 
@@ -293,7 +295,9 @@ static int buildjson(acarsmsg_t * msg, int chn, struct timeval tv)
 		}
 	}
 #ifdef HAVE_LIBACARS
-	cJSON_AddStringToObject(json_obj, "assstat", la_reasm_status_name_get(msg->reasm_status));
+	if (!skip_reassembly) {
+		cJSON_AddStringToObject(json_obj, "assstat", la_reasm_status_name_get(msg->reasm_status));
+	}
 	if(msg->decoded_tree != NULL) {
 		la_vstring *vstr = la_proto_tree_format_json(NULL, msg->decoded_tree);
 		cJSON_AddRawToObject(json_obj, "libacars", vstr->str);

--- a/output.c
+++ b/output.c
@@ -285,6 +285,13 @@ static int buildjson(acarsmsg_t * msg, int chn, struct timeval tv)
 		if(oooi.won[0])
 			cJSON_AddStringToObject(json_obj, "wlin", oooi.won);
 	}
+
+	if (msg->sublabel[0] != '\0') {
+		cJSON_AddStringToObject(json_obj, "sublabel", msg->sublabel);
+		if (msg->mfi[0] != '\0') {
+			cJSON_AddStringToObject(json_obj, "mfi", msg->mfi);
+		}
+	}
 #ifdef HAVE_LIBACARS
 	cJSON_AddStringToObject(json_obj, "assstat", la_reasm_status_name_get(msg->reasm_status));
 	if(msg->decoded_tree != NULL) {


### PR DESCRIPTION
* Switched to `getopt_long` to support new long args, `--skip-reassembly`
* Added new `--skip-reassembly` option to avoid reassembling ACARS message fragments
* Added `sublabel` and `mfi` keys to JSON output -- this data was available but not exposed in JSON output mode