### PR TITLE
Add option to use specific airspy device by serial number

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For RTL-SDR:
 
 For Airspy R2 / Mini:
 
-`acarsdec  [-o lv] [-t time] [-A] [-b filter ] [-e] [-n|N|j ipaddr:port] [-i stationid] [-l logfile [-H|-D]] [-g gain] [-k airspy_serial] -s f1 [f2] [... fN] | -s f1 [f2] [... fN]`
+> acarsdec  [-o lv] [-t time] [-A] [-b filter ] [-e] [-n|N|j ipaddr:port] [-i stationid] [-l logfile [-H|-D]] [-g gain] -s airspydevicenumber f1 [f2] [... fN] | -s f1 [f2] [... fN]
 
  -o lv :		output format : 0 : no log, 1 : one line by msg, 2 : full (default), 3 : monitor mode, 4 : msg JSON, 5 : route JSON
  
@@ -61,9 +61,7 @@ for the RTLSDR device
 for the AirSpy device
  -g gain :              set airspy gain (0..21)
 
- -k airspy_serial_number :            decode from airspy device with supplied serial number specified in hex, ie 0xA74068C82F591693
-
- -s f1 [f2] ... [fN] :		decode from airspy receiving at VHF frequencies "f1" and optionally "f2" to "fN" in Mhz (ie : -s  131.525 131.725 131.825 ). Frequencies must be within the same 2MHz.
+ -s airspydevice f1 [f2] ... [fN] :		decode from airspy device number or S/N "airspydevice" receiving at VHF frequencies "f1" and optionally "f2" to "fN" in Mhz (ie : -s  131.525 131.725 131.825 ). Frequencies must be within the same 2MHz.
 
 for the SDRplay device
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,14 @@ as the RTLSDR dongle, the AIRspy and the SDRplay device.
 It allows the user to directly monitor to up to 8 different frequencies simultaneously with very low cost hardware.
 
 ## Usage
+
+For RTL-SDR:
+
 > acarsdec  [-o lv] [-t time] [-A] [-b filter ] [-e] [-n|N|j ipaddr:port] [-i stationid] [-l logfile [-H|-D]] -r rtldevicenumber  f1 [f2] [... fN] | -s f1 [f2] [... fN]
+
+For Airspy R2:
+
+> acarsdec  [-o lv] [-t time] [-A] [-b filter ] [-e] [-n|N|j ipaddr:port] [-i stationid] [-l logfile [-H|-D]] [-g gain] [-k airspy_serial] -s f1 [f2] [... fN] | -s f1 [f2] [... fN]
 
  -o lv :		output format : 0 : no log, 1 : one line by msg, 2 : full (default), 3 : monitor mode, 4 : msg JSON, 5 : route JSON
  
@@ -50,7 +57,10 @@ for the RTLSDR device
  
  -p ppm :		set rtl ppm frequency correction
 
-for the AIRspy device
+for the AirSpy device
+ -g gain :              set airspy gain (0..21)
+
+ -k airspy_serial_number :            decode from airspy device with supplied serial number specified in hex, ie 0xA74068C82F591693
 
  -s f1 [f2] ... [fN] :		decode from airspy receiving at VHF frequencies "f1" and optionally "f2" to "fN" in Mhz (ie : -s  131.525 131.725 131.825 ). Frequencies must be within the same 2MHz.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For RTL-SDR:
 
 > acarsdec  [-o lv] [-t time] [-A] [-b filter ] [-e] [-n|N|j ipaddr:port] [-i stationid] [-l logfile [-H|-D]] -r rtldevicenumber  f1 [f2] [... fN] | -s f1 [f2] [... fN]
 
-For Airspy R2:
+For Airspy R2 / Mini:
 
 > acarsdec  [-o lv] [-t time] [-A] [-b filter ] [-e] [-n|N|j ipaddr:port] [-i stationid] [-l logfile [-H|-D]] [-g gain] [-k airspy_serial] -s f1 [f2] [... fN] | -s f1 [f2] [... fN]
 

--- a/acarsdec.c
+++ b/acarsdec.c
@@ -59,6 +59,7 @@ int rtlMult = 160;
 
 #ifdef WITH_AIR
 int gain = 18;
+uint64_t airspy_serial = 0;
 #endif
 
 #ifdef	WITH_SDRPLAY
@@ -108,7 +109,7 @@ static void usage(void)
 #endif
 #ifdef WITH_AIR
 	fprintf(stderr,
-		"[-g linearity_gain] -s f1 [f2] ... [fN]");
+		"[-g linearity_gain] [-k airspy_serial_number] -s f1 [f2] ... [fN]");
 #endif
 #ifdef	WITH_SDRPLAY
 	fprintf (stderr, " [-L lnaState] [-G GRdB] [-p ppm] -s f1 [f2] .. [fN]");
@@ -170,6 +171,8 @@ static void usage(void)
 	fprintf(stderr,
 		" -g linearity_gain\t: set linearity gain [0-21] default : 18\n");
 	fprintf(stderr,
+		" -k airspy_serial\t: airspy serial number to bind to i9n hex, (ie : 0xA74068C82F591693)\n");
+	fprintf(stderr,
 		" -s f1 [f2]...[f%d]\t: decode from airspy receiving at VHF frequencies f1 and optionally f2 to f%d in Mhz (ie : -s 131.525 131.725 131.825 )\n", MAXNBCHANNELS, MAXNBCHANNELS);
 #endif
 #ifdef	WITH_SDRPLAY
@@ -216,7 +219,7 @@ int main(int argc, char **argv)
 	idstation = strdup(sys_hostname);
 
 	res = 0;
-	while ((c = getopt_long(argc, argv, "HDvarfsRo:t:g:m:Aep:n:N:j:l:c:i:L:G:b:M:P:U:T:", long_opts, NULL)) != EOF) {
+	while ((c = getopt_long(argc, argv, "HDvarfsRo:t:g:k:m:Aep:n:N:j:l:c:i:L:G:b:M:P:U:T:", long_opts, NULL)) != EOF) {
 
 		switch (c) {
 		case 'v':
@@ -282,6 +285,9 @@ int main(int argc, char **argv)
 		case 's':
 			res = initAirspy(argv, optind);
 			inmode = 4;
+			break;
+		case 'k':
+			airspy_serial = strtoull(optarg, NULL, 16);
 			break;
     		case 'g':
 			gain = atoi(optarg);

--- a/acarsdec.c
+++ b/acarsdec.c
@@ -59,7 +59,6 @@ int rtlMult = 160;
 
 #ifdef WITH_AIR
 int gain = 18;
-uint64_t airspy_serial = 0;
 #endif
 
 #ifdef	WITH_SDRPLAY
@@ -109,7 +108,7 @@ static void usage(void)
 #endif
 #ifdef WITH_AIR
 	fprintf(stderr,
-		"[-g linearity_gain] [-k airspy_serial_number] -s f1 [f2] ... [fN]");
+		"[-g linearity_gain] -s airspydevicenumber f1 [f2] ... [fN]");
 #endif
 #ifdef	WITH_SDRPLAY
 	fprintf (stderr, " [-L lnaState] [-G GRdB] [-p ppm] -s f1 [f2] .. [fN]");
@@ -171,9 +170,7 @@ static void usage(void)
 	fprintf(stderr,
 		" -g linearity_gain\t: set linearity gain [0-21] default : 18\n");
 	fprintf(stderr,
-		" -k airspy_serial\t: airspy serial number to bind to i9n hex, (ie : 0xA74068C82F591693)\n");
-	fprintf(stderr,
-		" -s f1 [f2]...[f%d]\t: decode from airspy receiving at VHF frequencies f1 and optionally f2 to f%d in Mhz (ie : -s 131.525 131.725 131.825 )\n", MAXNBCHANNELS, MAXNBCHANNELS);
+		" -s airspydevice f1 [f2]...[f%d]\t: decode from airspy dongle number or hex serial number receiving at VHF frequencies f1 and optionally f2 to f%d in Mhz (ie : -s 131.525 131.725 131.825 )\n", MAXNBCHANNELS, MAXNBCHANNELS);
 #endif
 #ifdef	WITH_SDRPLAY
 	fprintf (stderr,
@@ -219,7 +216,7 @@ int main(int argc, char **argv)
 	idstation = strdup(sys_hostname);
 
 	res = 0;
-	while ((c = getopt_long(argc, argv, "HDvarfsRo:t:g:k:m:Aep:n:N:j:l:c:i:L:G:b:M:P:U:T:", long_opts, NULL)) != EOF) {
+	while ((c = getopt_long(argc, argv, "HDvarfsRo:t:g:m:Aep:n:N:j:l:c:i:L:G:b:M:P:U:T:", long_opts, NULL)) != EOF) {
 
 		switch (c) {
 		case 'v':
@@ -285,9 +282,6 @@ int main(int argc, char **argv)
 		case 's':
 			res = initAirspy(argv, optind);
 			inmode = 4;
-			break;
-		case 'k':
-			airspy_serial = strtoull(optarg, NULL, 16);
 			break;
     		case 'g':
 			gain = atoi(optarg);

--- a/acarsdec.h
+++ b/acarsdec.h
@@ -142,9 +142,6 @@ extern int mdly;
 extern int hourly, daily;
 
 extern int gain;
-#if defined(WITH_AIR)
-extern uint64_t airspy_serial;
-#endif
 extern int ppm;
 extern	int	lnaState;
 extern	int	GRdB;

--- a/acarsdec.h
+++ b/acarsdec.h
@@ -27,7 +27,7 @@
 
 #define ACARSDEC_VERSION "3.7"
 
-#define MAXNBCHANNELS 8
+#define MAXNBCHANNELS 16
 #define INTRATE 12500
 
 #define NETLOG_NONE 0
@@ -142,6 +142,9 @@ extern int mdly;
 extern int hourly, daily;
 
 extern int gain;
+#if defined(WITH_AIR)
+extern uint64_t airspy_serial;
+#endif
 extern int ppm;
 extern	int	lnaState;
 extern	int	GRdB;

--- a/air.c
+++ b/air.c
@@ -190,12 +190,6 @@ int initAirspy(char **argv, int optind)
 
 	/* init airspy */
 
-        if( result != AIRSPY_SUCCESS ) {
-		fprintf(stderr,"airspy_open() failed: %s (%d)\n", airspy_error_name(result), result);
-		airspy_exit();
-		return -1;
-	}
-
 	result = airspy_set_sample_type(device, AIRSPY_SAMPLE_FLOAT32_REAL);
 	if( result != AIRSPY_SUCCESS ) {
 		fprintf(stderr,"airspy_set_sample_type() failed: %s (%d)\n", airspy_error_name(result), result);

--- a/air.c
+++ b/air.c
@@ -39,26 +39,27 @@ static const unsigned int r820t_lf[]={525548,656935,795424,898403,1186034,150207
 
 static unsigned int chooseFc(unsigned int minF,unsigned int maxF,int filter)
 {
-	unsigned int bw=maxF-minF+2*INTRATE;
-	unsigned int off=0;
-	int i,j;
+        unsigned int bw=maxF-minF+2*INTRATE;
+        unsigned int off=0;
+        int i,j;
 
-	if(filter) {
-		for(i=7;i>=0;i--)
-			if((r820t_hf[5]-r820t_lf[i])>=bw) break;
-		if(i<0) return 0;
+        if(filter) {
+                for(i=7;i>=0;i--)
+                        if((r820t_hf[5]-r820t_lf[i])>=bw) break;
 
-		for(j=5;j>=0;j--)
-			if((r820t_hf[j]-r820t_lf[i])<=bw) break;
-		j++;
+                if(i<0) return 0;
 
-		off=(r820t_hf[j]+r820t_lf[i])/2-AIRINRATE/4;
+                for(j=5;j>=0;j--)
+                        if((r820t_hf[j]-r820t_lf[i])<=bw) break;
+                j++;
 
-        	airspy_r820t_write(device, 10, 0xB0 | (15-j));
-        	airspy_r820t_write(device, 11, 0xE0 | (15-i));
-	}
+                off=(r820t_hf[j]+r820t_lf[i])/2-AIRINRATE/4;
 
-	return(((maxF+minF)/2+off+INTRATE/2)/INTRATE*INTRATE);
+                airspy_r820t_write(device, 10, 0xB0 | (15-j));
+                airspy_r820t_write(device, 11, 0xE0 | (15-i));
+        }
+
+        return(((maxF+minF)/2+off+INTRATE/2)/INTRATE*INTRATE);
 }
 
 int initAirspy(char **argv, int optind)
@@ -102,7 +103,15 @@ int initAirspy(char **argv, int optind)
 
 	/* init airspy */
 
-	result = airspy_open(&device);
+	if (airspy_serial > 0) {
+	    if (verbose) {
+		fprintf(stderr, "attempting to open airspy serial 0x%016lx\n", airspy_serial);
+	    }
+	    result = airspy_open_sn(&device, airspy_serial);
+	} else {
+	    result = airspy_open(&device);
+	}
+
 	if( result != AIRSPY_SUCCESS ) {
 		fprintf(stderr,"airspy_open() failed: %s (%d)\n", airspy_error_name(result), result);
 		airspy_exit();
@@ -132,17 +141,19 @@ int initAirspy(char **argv, int optind)
 		AIRMULT=AIRINRATE/INTRATE;
 		if((AIRMULT*INTRATE)==AIRINRATE) break;
 	}
+
 	if(i>=count) {
 		fprintf(stderr,"did not find needed sampling rate\n");
 		airspy_close(device);
 		airspy_exit();
 		return -1;
 	}
+
 	free(supported_samplerates);
-	
+
 	if (verbose)
 		fprintf(stderr,"Using %d sampling rate\n",AIRINRATE);
-	
+
 
 	result = airspy_set_samplerate(device, i);
 	if( result != AIRSPY_SUCCESS ) {
@@ -195,7 +206,7 @@ int initAirspy(char **argv, int optind)
 		AMFreq = 2.0*M_PI*(double)(Fc-ch->Fr+AIRINRATE/4)/(double)(AIRINRATE);
 		for (i = 0, Ph=0; i < AIRMULT; i++) {
 			ch->wf[i]=cexpf(Ph*-I)/AIRMULT;
-			Ph+=AMFreq;	
+			Ph+=AMFreq;
 			if(Ph>2.0*M_PI) Ph-=2.0*M_PI;
 			if(Ph<-2.0*M_PI) Ph+=2.0*M_PI;
 		}
@@ -207,8 +218,7 @@ int initAirspy(char **argv, int optind)
 int ind=0;
 static int rx_callback(airspy_transfer_t* transfer)
 {
-
-	float* pt_rx_buffer;	
+	float* pt_rx_buffer;
 	int n,i;
         int bo,be,ben,nbk;
 
@@ -219,63 +229,63 @@ static int rx_callback(airspy_transfer_t* transfer)
         be=nbk*AIRMULT+bo;
         ben=transfer->sample_count-be;
 
-	for(n=0;n<nbch;n++) {
-        	channel_t *ch = &(channel[n]);
+        for(n=0;n<nbch;n++) {
+                channel_t *ch = &(channel[n]);
                 float S;
                 int k,bn,m;
-        	float complex D;
+                float complex D;
 
-        	D=ch->D;
+                D=ch->D;
 
                 /* compute */
                 m=0;k=0;
                 for (i=ind; i < AIRMULT;i++,k++) {
                         S = pt_rx_buffer[k];
                         D += ch->wf[i] * S;
-                 }
-                 ch->dm_buffer[m++]=cabsf(D);
+                }
+                ch->dm_buffer[m++]=cabsf(D);
 
-                 for (bn=0; bn<nbk;bn++) {
+                for (bn=0; bn<nbk;bn++) {
                         D=0;
                         for (i=0; i < AIRMULT;i++,k++) {
                                 S = pt_rx_buffer[k];
                                 D += ch->wf[i] * S;
                         }
                         ch->dm_buffer[m++]=cabsf(D);
-                 }
+                }
 
-                 D=0;
-                 for (i=0; i<ben;i++,k++) {
+                D=0;
+                for (i=0; i<ben;i++,k++) {
                         S = pt_rx_buffer[k];
                         D += ch->wf[i] * S;
-                 }
-        	 ch->D=D;
+                }
+                ch->D=D;
 
-                 demodMSK(ch,m);
-	}
+                demodMSK(ch,m);
+        }
         ind=ben;
 
 	return 0;
 }
 
 
-int runAirspySample(void) 
+int runAirspySample(void)
 {
- int result ;
+        int result;
 
- result = airspy_start_rx(device, rx_callback, NULL);
- if( result != AIRSPY_SUCCESS ) {
-	fprintf(stderr,"airspy_start_rx() failed: %s (%d)\n", airspy_error_name(result), result);
-	airspy_close(device);
-	airspy_exit();
-	return -1;
- }
+        result = airspy_start_rx(device, rx_callback, NULL);
+        if( result != AIRSPY_SUCCESS ) {
+                fprintf(stderr,"airspy_start_rx() failed: %s (%d)\n", airspy_error_name(result), result);
+                airspy_close(device);
+                airspy_exit();
+                return -1;
+        }
 
- while(airspy_is_streaming(device) == AIRSPY_TRUE) {
- 	sleep(2);
- }
+        while(airspy_is_streaming(device) == AIRSPY_TRUE) {
+                sleep(2);
+        }
 
- return 0;
+        return 0;
 }
 
 #endif


### PR DESCRIPTION
Adds the option to choose a specific airspy device while retaining existing parameter compatibility.