### PR TITLE
Better UDP output handling

### DIFF
--- a/netout.c
+++ b/netout.c
@@ -12,24 +12,33 @@
 #include "acarsdec.h"
 
 static int sockfd = -1;
+
+/* This is used to store a duplicate of the supplied argv destination addres */
 static char *netOutputRawaddr = NULL;
+
 
 static struct sockaddr *netOutputAddr = NULL;
 static int netOutputAddrLen = 0;
 
 int Netoutinit(char *Rawaddr)
 {
+        char tmpAddr[256];
 	char *addr;
 	char *port;
 	struct addrinfo hints, *servinfo, *p;
 	int rv;
 
-	netOutputRawaddr = Rawaddr;
+        if (Rawaddr) {
+            netOutputRawaddr = strdup(Rawaddr);
+        }
+
+        memset(tmpAddr, 0, 256);
+        strncpy(tmpAddr, netOutputRawaddr, 255);
 
 	memset(&hints, 0, sizeof hints);
-	if (Rawaddr[0] == '[') {
+	if (tmpAddr[0] == '[') {
 		hints.ai_family = AF_INET6;
-		addr = Rawaddr + 1;
+		addr = tmpAddr + 1;
 		port = strstr(addr, "]");
 		if (port == NULL) {
 			fprintf(stderr, "Invalid IPV6 address\n");
@@ -43,7 +52,7 @@ int Netoutinit(char *Rawaddr)
 			port++;
 	} else {
 		hints.ai_family = AF_UNSPEC;
-		addr = Rawaddr;
+		addr = tmpAddr;
 		port = strstr(addr, ":");
 		if (port == NULL)
 			port = "5555";
@@ -53,18 +62,22 @@ int Netoutinit(char *Rawaddr)
 		}
 	}
 
+        if (verbose) {
+            fprintf(stderr, "Attempting to resolve '%s:%s'.\n", addr, port);
+        }
+
 	hints.ai_socktype = SOCK_DGRAM;
 
 	if ((rv = getaddrinfo(addr, port, &hints, &servinfo)) != 0) {
             if (rv == EAI_AGAIN) {
-                fprintf(stderr, "Temporary error resolving %s, retrying later.\n", addr);
-                return -1;
+                fprintf(stderr, "Invalid/unknown error '%s' resolving '%s:%s', retrying later.\n", gai_strerror(rv), addr, port);
+                return 0;
             } else if (rv == EAI_FAIL) {
-                fprintf(stderr, "Host %s not found. Aborting.\n", addr);
-                exit(1);
+                fprintf(stderr, "Invalid/unknown failure '%s' resolving '%s:%s', aborting.\n", gai_strerror(rv), addr, port);
+                return -1;
             }
 
-            fprintf(stderr, "Invalid/unknown error '%s' resolving '%s', retrying later.\n", gai_strerror(rv), addr);
+            fprintf(stderr, "Invalid/unknown error '%s' resolving '%s:%s', retrying later.\n", gai_strerror(rv), addr, port);
             return -1;
 	}
 
@@ -73,19 +86,32 @@ int Netoutinit(char *Rawaddr)
                     continue;
 		}
 
+
                 netOutputAddrLen = p->ai_addrlen;
                 netOutputAddr = malloc(netOutputAddrLen);
                 memcpy(netOutputAddr, p->ai_addr, netOutputAddrLen);
-		break;
+
+                if (verbose) {
+                    char txtaddress[256];
+                    char txtport[256];
+                    memset(txtaddress, 0, 256);
+                    memset(txtport, 0, 256);
+                    if (getnameinfo(netOutputAddr, netOutputAddrLen, txtaddress, 255, txtport, 255, NI_NUMERICHOST | NI_NUMERICSERV | NI_DGRAM)) {
+                        fprintf(stderr, "Fail in getnameinfo().\n");
+                        return -1;
+                    }
+
+                    fprintf(stderr, "Successfully resolved '%s:%s' to %s:%s.\n", addr, port, txtaddress, txtport);
+                }
+                freeaddrinfo(servinfo);
+                return 0;
 	}
-	if (p == NULL) {
-		fprintf(stderr, "failed to resolve: %s\n", addr);
-		return -1;
-	}
+
+        fprintf(stderr, "failed to resolve: '%s:%s'\n", addr, port);
 
 	freeaddrinfo(servinfo);
 
-	return 0;
+	return -1;
 }
 
 static int Netwrite(const void *buf, size_t count) {
@@ -94,9 +120,12 @@ static int Netwrite(const void *buf, size_t count) {
         return -1;
     }
 
-    if (!netOutputAddrLen) { 
+    if (!netOutputAddrLen) {
         /* The destination address hasn't yet been succesfully resolved. */
-        res = Netoutinit(netOutputRawaddr);
+        if (verbose) {
+            fprintf(stderr, "retrying DNS resolution.\n");
+        }
+        res = Netoutinit(NULL);
         if(!res) {
             /* Resolution failed, so we'll drop this message and try again next time. */
             return res;
@@ -104,11 +133,14 @@ static int Netwrite(const void *buf, size_t count) {
     }
 
     res = sendto(sockfd, buf, count, 0, netOutputAddr, netOutputAddrLen);
-    if(!res && (errno == EAGAIN || errno == ECONNRESET || errno == EINTR)) {
-        /* Automatically retry these errors once and drop message if retry fails. */
-        return sendto(sockfd, buf, count, 0, netOutputAddr, netOutputAddrLen);
-    } else if (!res) {
-        perror("Netwrite");
+    if (res != count) {
+        if (errno == EAGAIN || errno == ECONNRESET || errno == EINTR) {
+            fprintf(stderr, "error on sendto(): %s, retrying.\n", strerror(errno));
+            /* Automatically retry these errors once and drop message if retry fails. */
+            return sendto(sockfd, buf, count, 0, netOutputAddr, netOutputAddrLen);
+        } else {
+            fprintf(stderr, "error on sendto(): %s, ignoring.\n", strerror(errno));
+        }
     }
 
     return res;


### PR DESCRIPTION
This adds some additional, conditional debugging of the networking code when verbose.
It allows for retrying DNS lookups so that acarsdec can still run and log locally if there's a network interruption.
It uses an unconnected UDP socket with sendto instead of connect+write which makes it easy to ignore transient errors.